### PR TITLE
Initial stab at the useProduction() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ Setting a unique endpoint **after** the Connector is instantiated
 Temporarily using the 'production' endpoint
 
     # Use the production endpoint for only the next $api->sendRequest() call
-    $api->useProduction();
-    
-    # Use the production endpoint for the next 5 $api->sendRequest() calls
-    $api->useProduction(5);    
+    $api->nextRequestProduction();
 
  Best used with the following packages:
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Create the object
 
     # start.php
 
-    // Optional
     use Waynestate\Api\Connector;
 
     ...
 
-    $api = new Waynestate\Api\Connector(API_KEY);
+    $api = new Connector(API_KEY);
 
     // Set the params
     $params = array(
@@ -33,6 +32,22 @@ Create the object
 
     // Get promotions from the API
     $promos = $api->sendRequest('cms/promotions/listing', $params);
+    
+Setting a unique endpoint **before** the Connector is instantiated
+
+    define('API_ENDPOINT', 'http://api.domain.com/v1/');
+    
+Setting a unique endpoint **after** the Connector is instantiated
+
+    $api->cmsREST = 'http://api.domain.com/v1/';
+    
+Temporarily using the 'production' endpoint
+
+    # Use the production endpoint for only the next $api->sendRequest() call
+    $api->useProduction();
+    
+    # Use the production endpoint for the next 5 $api->sendRequest() calls
+    $api->useProduction(5);    
 
  Best used with the following packages:
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -20,7 +20,7 @@ class Connector
         'user' => '',
     );
     private $active_endpoint = 'production';
-    private $prod_counter = 0;
+    private $force_production = false;
 
     public function __construct($apiKey = false, $mode = 'production')
     {
@@ -309,11 +309,10 @@ class Connector
     /**
      * Use the production endpoint for the next few calls
      *
-     * @param int $times
      */
-    public function useProduction($times = 1)
+    public function nextRequestProduction()
     {
-        $this->prod_counter = $times;
+        $this->force_production = true;
     }
 
     /**
@@ -324,7 +323,8 @@ class Connector
     protected function getEndpoint()
     {
         // If force production is in effect
-        if ($this->prod_counter-- > 0) {
+        if ($this->force_production) {
+            $this->force_production = false;
             return $this->endpoints['production'];
         }
 


### PR DESCRIPTION
Stemming from our discussion about the need to be able to easily be able to switch to the production API endpoint for a certain call to test data that is real (or not on the local dev environment).

This proposal is based on the needs above, ensuring backwards compatibility and with minimal impact on how the structure of this Connector works. _A complete 2.0 rewrite is bouncing around my head but now is not the time to start in that direction._
### How a user would interact with this feature

Setting a unique endpoint **before** the Connector is instantiated

``` php
define('API_ENDPOINT', 'http://api.domain.com/v1/');
```

Setting a unique endpoint **after** the Connector is instantiated

``` php
$api->cmsREST = 'http://api.domain.com/v1/';
```

Temporarily using the 'production' endpoint

``` php
# Use the production endpoint for only the next $api->sendRequest() call
$api->nextRequestProduction();
```
### Example

``` php
// Get the events from the API
$events_params = array(
    'site' => MAIN_SITE_ID,
    'limit' => 5,
    'end_date' => date('Y-m-d', strtotime('+6 month')),
    'ttl' => TTL,
);
$api->nextRequestProduction();
$all_event_listing = $api->sendRequest('calendar.events.listing', $events_params);
```
### Next steps

If this is the approach we want to take, I recommend a 1.1.0 release once this is merged. It doesn't break backwards compatibility but does add functionality.
