### PR TITLE
Hotfix/1.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "waynestate/waynestate-api",
   "description": "An API wrapper for the Wayne State University v1 API",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "require": {
     "php": ">=5.4"

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -36,13 +36,35 @@ class Connector
             $this->addEndpoint('user', API_ENDPOINT);
         }
 
-        if(getenv('WSUAPI_ENDPOINT') != ''){
-            $this->addEndPoint('user', getenv('WSUAPI_ENDPOINT'));
+        $envVariables = $this->getEnvVariables();
+
+        if(!empty($envVariables['WSUAPI_ENDPOINT'])){
+            $this->addEndPoint('user', $envVariables['WSUAPI_ENDPOINT']);
         }
 
         if (defined('API_CACHE_DIR') && API_CACHE_DIR != '') {
             $this->cache_dir = API_CACHE_DIR;
         }
+    }
+
+    /**
+     * Get the Environment Variables
+     *
+     * If the Laravel Helper function env is available then use it, otherwise getenv
+     *
+     * @return array
+     */
+    private function getEnvVariables()
+    {
+        if(function_exists('env')){
+            return [
+                'WSUAPI_ENDPOINT' => env('WSUAPI_ENDPOINT'),
+            ];
+        }
+
+        return [
+            'WSUAPI_ENDPOINT' => getenv('WSUAPI_ENDPOINT'),
+        ];
     }
 
     /**


### PR DESCRIPTION
Using Laravel 5.8 now only relies on env() to get the environment variables from the .env this uses either getenv or env if available