### PR TITLE
Small fix to prevent Undefined array key HTTP_USER_AGENT

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -210,7 +210,7 @@ class Connector
         curl_setopt($curl_handle, CURLOPT_CONNECTTIMEOUT, 1);
         curl_setopt($curl_handle, CURLOPT_HEADER, 0);
         curl_setopt($curl_handle, CURLOPT_TIMEOUT, 20);
-        curl_setopt($curl_handle, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+        curl_setopt($curl_handle, CURLOPT_USERAGENT, (array_key_exists('HTTP_USER_AGENT', $_SERVER)?$_SERVER['HTTP_USER_AGENT']:''));
         curl_setopt($curl_handle, CURLOPT_REFERER, 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
         curl_setopt($curl_handle, CURLOPT_SSL_VERIFYPEER, false);
 


### PR DESCRIPTION
To prevent log entries on the notice of an optional field:
`production.ERROR: Undefined array key "HTTP_USER_AGENT" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"HTTP_USER_AGENT\"`